### PR TITLE
fix: current user now displays first name and last name too

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :email, :document_number
+  attributes :id, :email, :document_number, :first_name, :last_name
 end


### PR DESCRIPTION
## JIRA Card

https://widergy.atlassian.net/browse/TR-689

## Summary

Inicialmente la respuesta del servicio current_user mostraba id, email y document_number, pero se requería que ademas muestre el nombre y el apellido del user.

Con estos cambios el servicio current_user muestra id, email, document_number, first_name y last_name

## Screenshots

<img width="1002" alt="Captura de pantalla 2025-01-30 a la(s) 12 07 47 p  m" src="https://github.com/user-attachments/assets/2f90e328-e998-411d-80ca-0d17b31b0cdf" />
